### PR TITLE
adding Proxmox VE support to kernel-headers package

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -17,11 +17,21 @@ class serverbackup_cdp_agent::packages {
     
     if $operatingsystem == ('debian') {
     
-        package { "linux-headers-${kernelrelease}":
-            ensure  => installed,
-            require => Class['serverbackup_cdp_agent::repo'],
-            before => Package['serverbackup-enterprise-agent'],
-        }
+		if $kernelrelease  =~ /pve/ {
+	        package { "pve-headers-${kernelrelease}":
+            	ensure  => installed,
+            	require => Class['serverbackup_cdp_agent::repo'],
+            	before => Package['serverbackup-enterprise-agent'],
+        	}
+		}
+		else {
+
+			package { "linux-headers-${kernelrelease}":
+        	    ensure  => installed,
+        	    require => Class['serverbackup_cdp_agent::repo'],
+        	    before => Package['serverbackup-enterprise-agent'],
+        	}
+		}
     }
 
     package { 'serverbackup-enterprise-agent':


### PR DESCRIPTION
i have a few Proxmox servers that fail with this module because the proxmox kernel headers are differently named

i've done an if that detects if the kernelrelease fact contains pve to install the pve package from the correct name, otherwise default to debian standard kernel header packages

confirmed to work on both proxmox and non proxmox debian systems and no dodgy " chars this time
