### PR TITLE
Add Idera server support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2013-09-23 Anthony Somerset http://www.somersettechsolutions.co.uk 0.4.0
+Added support for installing CDP Server
+Note: Class name has changed from serverbackup_cdp_agent to serverbackup_cdp as have classes.
 2013-09-15 Anthony Somerset http://www.somersettechsolutions.co.uk 0.3.1
 Added proxmox support
 2013-09-04 Anthony Somerset http://www.somersettechsolutions.co.uk 0.3.0

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'lboynton-r1soft_cdp_agent'
-version '0.3.1'
+version '0.4.0'
 source 'https://github.com/lboynton/puppet-r1soft-cdp-agent'
 author 'lboynton'
 summary "Installs and sets up the Idera (formerly R1Soft) CDP agent on CentOS/RHEL or Ubuntu/Debian"

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@ Puppet Idera (formerly R1Soft) CDP Agent module
 
 Tested on Debian 7.0, CentOS 6 and Ubuntu 12.04.2 LTS.
 
+Major Update - now supports install of CDP server - Please note the change in class behaviour below and change in class names
+
 Usage
 --------------
+CDP Agent Only: 
+
 Simply specify the IP address or hostname of the CDP master to the `key_server` parameter.
 
 ```puppet
-class { 'serverbackup_cdp_agent':
+class { 'serverbackup_cdp::agent':
 	key_server => 'http://192.168.0.25:8080',
 }
 ```
@@ -16,7 +20,30 @@ class { 'serverbackup_cdp_agent':
 Alternatively you can also specify the key directly.
 
 ```puppet
-class { 'serverbackup_cdp_agent':
+class { 'serverbackup_cdp::agent':
+	key => 'xxxxxxxxx',
+}
+```
+
+CDP Server Only:
+
+```puppet
+class { 'serverbackup_cdp':
+}
+```
+or even simpler
+
+```puppet
+include serverbackup_cdp
+}
+```
+
+CDP Agent & Server:
+```puppet
+class { 'serverbackup_cdp':
+	install_agent => true,
+	# and only one of the following
+	key_server => 'http://192.168.0.25:8080',
 	key => 'xxxxxxxxx',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ or even simpler
 
 ```puppet
 include serverbackup_cdp
-}
 ```
 
 CDP Agent & Server:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
-  config.vm.synced_folder ".", "/srv/puppet/modules/serverbackup_cdp_agent", :nfs => true
+  config.vm.synced_folder ".", "/srv/puppet/modules/serverbackup_cdp", :nfs => true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -3,8 +3,10 @@ class serverbackup_cdp::agent(
     $key = $serverbackup_cdp::params::key,
 	$install_agent	    = $serverbackup_cdp::params::install_agent
 ) {
-	if $install_agent = false {
-    	include serverbackup_cdp::repo
+	if $install_agent {
+		#noop because negative if on boolean not great in puppet
+	} else {
+    		include serverbackup_cdp::repo
 	}
     include serverbackup_cdp::agent::packages
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,0 +1,31 @@
+class serverbackup_cdp::agent(
+    $key_server = $serverbackup_cdp::params::key_server,
+    $key = $serverbackup_cdp::params::key,
+	$install_agent	    = $serverbackup_cdp::params::install_agent
+) {
+	if $install_agent == 'false' {
+    	include serverbackup_cdp::repo
+	}
+    include serverbackup_cdp::agent::packages
+
+    exec { 'get-module':
+        command     => '/usr/bin/serverbackup-setup --get-module --silent',
+        subscribe   => Package['serverbackup-enterprise-agent'],
+        unless      => '/bin/grep hcpdriver /proc/modules',
+        logoutput   => on_failure,
+    }
+
+    service { 'cdp-agent':
+        ensure      => running,
+        enable      => true,
+        subscribe   => Exec['get-module'],
+    }
+
+    if ($key != undef) {
+        serverbackup_cdp::agent::key{$key:}
+    }
+    elsif ($key_server != undef)  {
+        serverbackup_cdp::agent::get_key{$key_server:}
+    }
+}
+

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -3,7 +3,7 @@ class serverbackup_cdp::agent(
     $key = $serverbackup_cdp::params::key,
 	$install_agent	    = $serverbackup_cdp::params::install_agent
 ) {
-	if $install_agent == 'false' {
+	if $install_agent == false {
     	include serverbackup_cdp::repo
 	}
     include serverbackup_cdp::agent::packages

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -3,7 +3,7 @@ class serverbackup_cdp::agent(
     $key = $serverbackup_cdp::params::key,
 	$install_agent	    = $serverbackup_cdp::params::install_agent
 ) {
-	if $install_agent == false {
+	if $install_agent = false {
     	include serverbackup_cdp::repo
 	}
     include serverbackup_cdp::agent::packages

--- a/manifests/agent/get_key.pp
+++ b/manifests/agent/get_key.pp
@@ -1,4 +1,4 @@
-define serverbackup_cdp_agent::get_key {
+define serverbackup_cdp::agent::get_key {
     $server_filename = regsubst($name, '^(.*:)//([a-z0-9\-.]+)(:[0-9]+)?(.*)$','\2')
     exec { "/usr/bin/serverbackup-setup --get-key ${name}":
         creates     => "/usr/sbin/r1soft/conf/server.allow/${server_filename}",

--- a/manifests/agent/key.pp
+++ b/manifests/agent/key.pp
@@ -1,4 +1,4 @@
-define serverbackup_cdp_agent::key {
+define serverbackup_cdp::agent::key {
     file { "/usr/sbin/r1soft/conf/server.allow/key":
         content => "${title}",
         notify      => Service['cdp-agent'],

--- a/manifests/agent/packages.pp
+++ b/manifests/agent/packages.pp
@@ -1,4 +1,4 @@
-class serverbackup_cdp_agent::packages {
+class serverbackup_cdp::agent::packages {
     if $operatingsystem == ('redhat' or 'centos') {
         if !defined(Package['kernel-devel']) {
             package { 'kernel-devel':
@@ -20,14 +20,14 @@ class serverbackup_cdp_agent::packages {
         if $kernelrelease  =~ /pve/ {
             package { "pve-headers-${kernelrelease}":
                 ensure  => installed,
-                require => Class['serverbackup_cdp_agent::repo'],
+                require => Class['serverbackup_cdp::repo'],
                 before => Package['serverbackup-enterprise-agent'],
             }
         }
         else {
             package { "linux-headers-${kernelrelease}":
                 ensure  => installed,
-                require => Class['serverbackup_cdp_agent::repo'],
+                require => Class['serverbackup_cdp::repo'],
                 before => Package['serverbackup-enterprise-agent'],
             }
         }
@@ -35,6 +35,6 @@ class serverbackup_cdp_agent::packages {
 
     package { 'serverbackup-enterprise-agent':
         ensure  => installed,
-        require => Class['serverbackup_cdp_agent::repo'],
+        require => Class['serverbackup_cdp::repo'],
     }
 }

--- a/manifests/agent/packages.pp
+++ b/manifests/agent/packages.pp
@@ -20,14 +20,12 @@ class serverbackup_cdp::agent::packages {
         if $kernelrelease  =~ /pve/ {
             package { "pve-headers-${kernelrelease}":
                 ensure  => installed,
-                require => Class['serverbackup_cdp::repo'],
                 before => Package['serverbackup-enterprise-agent'],
             }
         }
         else {
             package { "linux-headers-${kernelrelease}":
                 ensure  => installed,
-                require => Class['serverbackup_cdp::repo'],
                 before => Package['serverbackup-enterprise-agent'],
             }
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,28 +1,22 @@
-class serverbackup_cdp_agent(
-    $key_server = undef,
-    $key = undef
-) {
-    include serverbackup_cdp_agent::repo
-    include serverbackup_cdp_agent::packages
+class serverbackup_cdp(
+$key_server 		= $serverbackup_cdp::params::key_server,
+$key 				= $serverbackup_cdp::params::key,
+$install_agent	    = $serverbackup_cdp::params::install_agent
+) inherits serverbackup_cdp::params  {
 
-    exec { 'get-module':
-        command     => '/usr/bin/serverbackup-setup --get-module --silent',
-        subscribe   => Package['serverbackup-enterprise-agent'],
-        unless      => '/bin/grep hcpdriver /proc/modules',
-        logoutput   => on_failure,
+	# default class action is to install the server!
+    include serverbackup_cdp::repo
+	include serverbackup_cdp::server
+	
+    if $install_agent {
+      class { 'serverbackup_cdp::agent':
+        key_server => $key_server,
+		key		   => $key,
+		install_agent => $install_agent
+      }
     }
+	
+	
 
-    service { 'cdp-agent':
-        ensure      => running,
-        enable      => true,
-        subscribe   => Exec['get-module'],
-    }
-
-    if ($key != undef) {
-        serverbackup_cdp_agent::key{$key:}
-    }
-    elsif ($key_server != undef)  {
-        serverbackup_cdp_agent::get_key{$key_server:}
-    }
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,26 @@
+class serverbackup_cdp::params{
+  # If we have a top scope variable defined, use it, otherwise fall back to a
+  # hardcoded value.
+  $key_server = $::key_server ? {
+  	undef => undef,
+	default => $::key_server,
+  }
+  
+  $key_server = $::key ? {
+  	undef => undef,
+	default => $::key,
+  }
+  
+  # Since the top scope variable could be a string (if from an ENC), we might
+  # need to convert it to a boolean.
+  $install_agent = $::install_agent ? {
+    undef   => false,
+    default => $::install_agent,
+  }
+  if is_string($install_agent) {
+    $safe_install_agent = str2bool($install_agent)
+  } else {
+    $safe_install_agent = $install_agent
+  }
+  
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class serverbackup_cdp::params{
 	default => $::key_server,
   }
   
-  $key_server = $::key ? {
+  $key = $::key ? {
   	undef => undef,
 	default => $::key,
   }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,4 +1,4 @@
-class serverbackup_cdp_agent::repo {
+class serverbackup_cdp::repo {
     case $operatingsystem {
         redhat, centos: {
             yumrepo { 'r1soft':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,7 +16,7 @@ class serverbackup_cdp::repo {
                 repos       => 'main',
                 include_src => false,
                 key         => 'B1D53877',
-                key_source  => 'http://repo.r1soft.com/r1soft.asc',
+                key_source  => 'http://repo.r1soft.com/apt/r1soft.asc',
             }
         }
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -15,7 +15,7 @@ class serverbackup_cdp::repo {
                 release     => 'stable',
                 repos       => 'main',
                 include_src => false,
-                key         => 'B1D53877',
+                key         => 'A40384ED',
                 key_source  => 'http://repo.r1soft.com/apt/r1soft.asc',
             }
         }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,0 +1,13 @@
+   class serverbackup_cdp::server {
+   
+    package { 'serverbackup-enterprise':
+        ensure  => installed,
+        require => Class['serverbackup_cdp::repo'],
+    }
+	
+    service { 'cdp-server':
+        ensure      => running,
+        enable      => true,
+    }
+	
+}

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,1 +1,1 @@
-include serverbackup_cdp_agent
+include serverbackup_cdp


### PR DESCRIPTION
this is a major BREAKING change!

the idea here is that if you have to install cdp agents you likely have to install cdp servers somewhere

this is a rewrite of the module to support this, as a result the class name was changed from serverbackup_cdp_agent to just serverbackup_cdp - readme updated

calling just serverbackup_cdp with no arguments will install the CDP server ONLY

you can pass the variable install_agent (as well as the normal key_server param) to be true to install the client as well as the CDP server or you can proceed as previously to call the agent manifest directly via serverbackup_cdp::agent - passing the same variables as done with the previous version

the tests still needs work however i have confirmed that server only and agent only installs work correctly on real servers
